### PR TITLE
Use if-none-match and avoid head request

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = function(callback) {
 
 		var localEtag = data.toString();
 
-		req.head(URL, function(err, res) {
-			if (res.headers.etag === localEtag) {
+		req(URL, {headers:{'if-none-match':localEtag}}, function(err, res) {
+			if (res.statusCode === 304) {
 				return fs.readFile(DATA_FILE, function(err, data) {
 					if (err) return callback(err);
 
@@ -24,14 +24,10 @@ module.exports = function(callback) {
 			fs.writeFile(ETAG_FILE, res.headers.etag, function(err) {
 				if (err) return callback(err);
 
-				req(URL, function(err, res) {
+				fs.writeFile(DATA_FILE, res.body, function(err) {
 					if (err) return callback(err);
 
-					fs.writeFile(DATA_FILE, res.body, function(err) {
-						if (err) return callback(err);
-
-						callback(null, JSON.parse(res.body));
-					});
+					callback(null, JSON.parse(res.body));
 				});
 			});
 		});


### PR DESCRIPTION
Small change that uses the `if-none-match` header when doing the request.
This removes the need for the initial head request.
